### PR TITLE
Add Solana network support to documentation

### DIFF
--- a/core-concepts/network-and-token-support.md
+++ b/core-concepts/network-and-token-support.md
@@ -40,11 +40,14 @@ Additional facilitators may be available from external providers. Check the [x40
 
 ### Token Support
 
-x402 supports any ERC-20 token that implements the EIP-3009 standard.
+x402 supports tokens on both EVM and Solana networks:
 
-**Important**: Facilitators support networks, not specific tokens - any EIP-3009 compatible token works on any facilitator.
+* **EVM**: Any ERC-20 token that implements the EIP-3009 standard
+* **Solana**: Any SPL token
 
-#### EIP-3009 Requirement
+**Important**: Facilitators support networks, not specific tokens — any EIP-3009 compatible token works on EVM networks, and any SPL token works on Solana, for the facilitators that support those networks.
+
+#### EVM: EIP-3009 Requirement
 
 Tokens must implement the `transferWithAuthorization` function from the EIP-3009 standard. This enables:
 
@@ -85,6 +88,10 @@ These values are used in the `eip712` nested object when configuring TokenAmount
 }
 ```
 
+#### Solana: SPL Tokens
+
+On Solana, x402 supports all SPL tokens. When using facilitators that support Solana or Solana Devnet, payments can be made in any SPL token, including USDC (SPL). No EIP-712 configuration is required on Solana.
+
 #### USDC - The Default Token
 
 * **Status**: Supported by default across all networks
@@ -108,7 +115,7 @@ The EIP-3009 standard is essential for x402 because it enables:
 | x402.rs         | base-sepolia, base, xdc                 | ✅               | None            |
 | Self-hosted     | Any EVM network                         | ✅               | Technical setup |
 
-**Note**: All facilitators support any EIP-3009 compatible token on their supported networks.
+**Note**: On EVM networks, facilitators support any EIP-3009 compatible token; on Solana, facilitators support any SPL token.
 
 ### Adding Support for New Networks
 
@@ -194,7 +201,7 @@ Video Guide: [Adding EVM Chains to x402](https://x.com/jaycoolh/status/192085155
 The x402 ecosystem is actively expanding network support. Planned additions include:
 
 * Additional L2 networks
-* Non-EVM chain support (Solana in development)
+* Additional non-EVM chain support
 * Cross-chain payment capabilities
 
 ### Getting Help

--- a/core-concepts/network-and-token-support.md
+++ b/core-concepts/network-and-token-support.md
@@ -103,8 +103,8 @@ The EIP-3009 standard is essential for x402 because it enables:
 
 | Facilitator     | Networks Supported                      | Production Ready | Requirements    |
 | --------------- | --------------------------------------- | ---------------- | --------------- |
-| x402.org        | base-sepolia, solana-testnet            | ❌ Testnet only  | None            |
-| CDP Facilitator | base, base-sepolia, solana, solana-test | ✅               | CDP API keys    |
+| x402.org        | base-sepolia, solana-devnet            | ❌ Testnet only  | None            |
+| CDP Facilitator | base, base-sepolia, solana, solana-devnet | ✅               | CDP API keys    |
 | x402.rs         | base-sepolia, base, xdc                 | ✅               | None            |
 | Self-hosted     | Any EVM network                         | ✅               | Technical setup |
 

--- a/core-concepts/network-and-token-support.md
+++ b/core-concepts/network-and-token-support.md
@@ -12,13 +12,13 @@ Network support in x402 depends on which facilitator you use. Here are the curre
 
 #### x402.org Facilitator
 
-* **Supports**: Base Sepolia
+* **Supports**: Base Sepolia, Solana Testnet
 * **Notes**: Recommended for testing and development. This is the default facilitator in the x402 packages and requires no setup.
 * **URL**: https://x402.org/facilitator
 
 #### CDP's x402 Facilitator
 
-* **Supports**: Base, Base Sepolia
+* **Supports**: Base, Base Sepolia, Solana, Solana Testnet
 * **Notes**: Production-ready for mainnet payments with KYT/OFAC compliance checks. Can also be used for testing on Base Sepolia. Requires CDP API keys. Uses facilitator object instead of facilitator URL.
 * **Requirements**: CDP account and API keys from [cdp.coinbase.com](https://cdp.coinbase.com), see Quickstart for Sellers: Running on Mainnet for more details.
 
@@ -101,12 +101,12 @@ The EIP-3009 standard is essential for x402 because it enables:
 
 ### Quick Reference
 
-| Facilitator     | Networks Supported      | Production Ready | Requirements    |
-| --------------- | ----------------------- | ---------------- | --------------- |
-| x402.org        | base-sepolia            | ❌ Testnet only   | None            |
-| CDP Facilitator | base, base-sepolia      | ✅                | CDP API keys    |
-| x402.rs         | base-sepolia, base, xdc | ✅                | None            |
-| Self-hosted     | Any EVM network         | ✅                | Technical setup |
+| Facilitator     | Networks Supported                      | Production Ready | Requirements    |
+| --------------- | --------------------------------------- | ---------------- | --------------- |
+| x402.org        | base-sepolia, solana-testnet            | ❌ Testnet only  | None            |
+| CDP Facilitator | base, base-sepolia, solana, solana-test | ✅               | CDP API keys    |
+| x402.rs         | base-sepolia, base, xdc                 | ✅               | None            |
+| Self-hosted     | Any EVM network                         | ✅               | Technical setup |
 
 **Note**: All facilitators support any EIP-3009 compatible token on their supported networks.
 

--- a/core-concepts/network-and-token-support.md
+++ b/core-concepts/network-and-token-support.md
@@ -12,13 +12,13 @@ Network support in x402 depends on which facilitator you use. Here are the curre
 
 #### x402.org Facilitator
 
-* **Supports**: Base Sepolia, Solana Testnet
+* **Supports**: Base Sepolia, Solana Devnet
 * **Notes**: Recommended for testing and development. This is the default facilitator in the x402 packages and requires no setup.
 * **URL**: https://x402.org/facilitator
 
 #### CDP's x402 Facilitator
 
-* **Supports**: Base, Base Sepolia, Solana, Solana Testnet
+* **Supports**: Base, Base Sepolia, Solana, Solana Devnet
 * **Notes**: Production-ready for mainnet payments with KYT/OFAC compliance checks. Can also be used for testing on Base Sepolia. Requires CDP API keys. Uses facilitator object instead of facilitator URL.
 * **Requirements**: CDP account and API keys from [cdp.coinbase.com](https://cdp.coinbase.com), see Quickstart for Sellers: Running on Mainnet for more details.
 

--- a/faq.md
+++ b/faq.md
@@ -63,7 +63,7 @@ Yes. x402 handles the _payment execution_. You can still meter usage, aggregate 
 | ------------   | ----- | -------- | ----------- |
 | Base           | USDC  | fee-free | **Mainnet** |
 | Base Sepolia   | USDC  | fee-free | **Testnet** |
-| Solana         | USDC  | fee-free | **Mainnet** |
+| Solana         | SPL Tokens  | fee-free | **Mainnet** |
 | Solana Devnet | SPL Tokens  | fee-free | **Testnet** |
 
 * Gas paid on chain; Coinbase's x402 facilitator adds **zero** facilitator fee.

--- a/faq.md
+++ b/faq.md
@@ -59,10 +59,12 @@ Yes. x402 handles the _payment execution_. You can still meter usage, aggregate 
 
 #### Which assets and networks are supported today?
 
-| Network      | Asset | Fees\*   | Status      |
-| ------------ | ----- | -------- | ----------- |
-| Base         | USDC  | fee-free | **Mainnet** |
-| Base Sepolia | USDC  | fee-free | **Testnet** |
+| Network        | Asset | Fees\*   | Status      |
+| ------------   | ----- | -------- | ----------- |
+| Base           | USDC  | fee-free | **Mainnet** |
+| Base Sepolia   | USDC  | fee-free | **Testnet** |
+| Solana         | USDC  | fee-free | **Mainnet** |
+| Solana Testnet | USDC  | fee-free | **Testnet** |
 
 * Gas paid on chain; Coinbase's x402 facilitator adds **zero** facilitator fee.
 

--- a/faq.md
+++ b/faq.md
@@ -64,7 +64,7 @@ Yes. x402 handles the _payment execution_. You can still meter usage, aggregate 
 | Base           | USDC  | fee-free | **Mainnet** |
 | Base Sepolia   | USDC  | fee-free | **Testnet** |
 | Solana         | USDC  | fee-free | **Mainnet** |
-| Solana Testnet | USDC  | fee-free | **Testnet** |
+| Solana Devnet | SPL Tokens  | fee-free | **Testnet** |
 
 * Gas paid on chain; Coinbase's x402 facilitator adds **zero** facilitator fee.
 

--- a/getting-started/quickstart-for-buyers.md
+++ b/getting-started/quickstart-for-buyers.md
@@ -17,7 +17,7 @@ We have pre-configured [examples available in our repo](https://github.com/coinb
 
 {% tabs %}
 {% tab title="Node.js" %}
-**HTTP Clients (Axios/Fetch)**  
+**HTTP Clients (Axios/Fetch)**
 Install [x402-axios](https://www.npmjs.com/package/x402-axios) or [x402-fetch](https://www.npmjs.com/package/x402-fetch):
 
 ```bash
@@ -26,7 +26,7 @@ npm install x402-axios
 npm install x402-fetch
 ```
 
-**MCP (Unofficial)**  
+**MCP (Unofficial)**
 This [community package](https://github.com/ethanniser/x402-mcp) showcases how AI agents can use Model Context Protocol (MCP) with x402. We're working on enshrining an official MCP spec in x402 soon.
 
 Install the required packages for MCP support:
@@ -49,19 +49,17 @@ pip install x402
 
 ### 2. Create a Wallet Client
 
-#### **Node.js**
-
-Create a wallet client using a tool like [viem](https://viem.sh/):&#x20;
+#### Create a Wallet Client
 
 {% tabs %}
-{% tab title="Viem" %}
-First, install the required packages:
+{% tab title="Node.js (viem)" %}
+Install the required package:
 
 ```bash
 npm install viem
 ```
 
-Then, instantiate the wallet account:
+Then instantiate the wallet account:
 
 ```typescript
 import { createWalletClient, http } from "viem";
@@ -72,29 +70,37 @@ import { baseSepolia } from "viem/chains";
 const account = privateKeyToAccount("0xYourPrivateKey"); // we recommend using an environment variable for this
 ```
 {% endtab %}
-{% endtabs %}
 
-#### **Python**
+{% tab title="Python (eth-account)" %}
+Install the required package:
 
-Create a wallet client using a tool like [eth-account](https://github.com/ethereum/eth-account):
-
-{% tabs %}
-{% tab title="eth-account" %}
-First, install the required packages:
-
-```
+```bash
 pip install eth_account
 ```
 
-Then, instantiate the wallet account:
+Then instantiate the wallet account:
 
 ```python
 from eth_account import Account
 
-account = Account.from_key("your_private_key") # we recommend using an environment variable fo
+account = Account.from_key("your_private_key") # we recommend using an environment variable for this
 ```
 {% endtab %}
 {% endtabs %}
+
+#### Solana (SVM)
+
+Use [SolanaKit](https://www.solanakit.com/) to instantiate a signer:
+
+```typescript
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { base58 } from "@scure/base";
+
+// 64-byte base58 secret key (private + public)
+const signer = await createKeyPairSignerFromBytes(
+  base58.decode(process.env.SOLANA_PRIVATE_KEY!)
+);
+```
 
 ### 3. Make Paid Requests Automatically
 
@@ -174,7 +180,7 @@ import { withPayment } from "x402-mcp";
 // Create MCP client with payment capabilities
 const mcpClient = await createMCPClient({
   transport: new StreamableHTTPClientTransport(mcpServerUrl), // URL of your MCP server
-}).then((client) => withPayment(client, { 
+}).then((client) => withPayment(client, {
   account, // Your wallet account from step 2
   network: "base" // or "base-sepolia" for testnet
 }));

--- a/getting-started/quickstart-for-sellers.md
+++ b/getting-started/quickstart-for-sellers.md
@@ -69,7 +69,7 @@ Full example in the repo [here](https://github.com/ethanniser/x402-mcp/tree/main
 
 ```bash
 pip install x402
-pip install cdp # for the mainnet facilitator 
+pip install cdp # for the mainnet facilitator
 ```
 {% endtab %}
 {% endtabs %}
@@ -78,7 +78,7 @@ pip install cdp # for the mainnet facilitator
 
 Integrate the payment middleware into your application. You will need to provide:
 
-* The Facilitator URL or facilitator object. For testing, use `https://x402.org/facilitator` which works on Base Sepolia.
+* The Facilitator URL or facilitator object. For testing, use `https://x402.org/facilitator` which works on Base Sepolia and Solana testnet.
   * For more information on running in production on mainnet, check out [CDP's Quickstart for Sellers](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers)
 * The routes you want to protect.
 * Your receiving wallet address.
@@ -94,7 +94,7 @@ import { paymentMiddleware, Network } from "x402-express";
 const app = express();
 
 app.use(paymentMiddleware(
-  "0xYourAddress", // your receiving wallet address 
+  "0xYourAddress", // your receiving wallet address
   {  // Route configurations for protected endpoints
       "GET /weather": {
         // USDC amount in dollars
@@ -103,7 +103,7 @@ app.use(paymentMiddleware(
       },
     },
   {
-    url: "https://x402.org/facilitator", // Facilitator URL for Base Sepolia testnet. 
+    url: "https://x402.org/facilitator", // Facilitator URL for Base Sepolia testnet.
   }
 ));
 
@@ -131,7 +131,7 @@ import { paymentMiddleware, Network } from 'x402-next';
 
 // Configure the payment middleware
 export const middleware = paymentMiddleware(
-  "0xYourAddress", // your receiving wallet address 
+  "0xYourAddress", // your receiving wallet address
   {  // Route configurations for protected endpoints
     '/protected': {
       price: '$0.01',
@@ -142,7 +142,7 @@ export const middleware = paymentMiddleware(
     },
   }
   {
-    url: "https://x402.org/facilitator", // Facilitator URL for Base Sepolia testnet. 
+    url: "https://x402.org/facilitator", // Facilitator URL for Base Sepolia testnet.
   }
 );
 
@@ -167,7 +167,7 @@ const app = new Hono();
 
 // Configure the payment middleware
 app.use(paymentMiddleware(
-  "0xYourAddress", // your receiving wallet address 
+  "0xYourAddress", // your receiving wallet address
   {  // Route configurations for protected endpoints
     "/protected-route": {
       price: "$0.10",
@@ -178,7 +178,7 @@ app.use(paymentMiddleware(
     }
   },
   {
-    url: "https://x402.org/facilitator", // Facilitator URL for Base Sepolia testnet. 
+    url: "https://x402.org/facilitator", // Facilitator URL for Base Sepolia testnet.
   }
 ));
 
@@ -221,7 +221,7 @@ const handler = createPaidMcpHandler(
         };
       }
     );
-    
+
     // Add more paid tools as needed
     server.paidTool(
       "premium_feature",

--- a/getting-started/quickstart-for-sellers.md
+++ b/getting-started/quickstart-for-sellers.md
@@ -78,7 +78,7 @@ pip install cdp # for the mainnet facilitator
 
 Integrate the payment middleware into your application. You will need to provide:
 
-* The Facilitator URL or facilitator object. For testing, use `https://x402.org/facilitator` which works on Base Sepolia and Solana testnet.
+* The Facilitator URL or facilitator object. For testing, use `https://x402.org/facilitator` which works on Base Sepolia and Solana devnet.
   * For more information on running in production on mainnet, check out [CDP's Quickstart for Sellers](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers)
 * The routes you want to protect.
 * Your receiving wallet address.

--- a/guides/mcp-server-with-x402.md
+++ b/guides/mcp-server-with-x402.md
@@ -18,7 +18,7 @@ This lets you (or your agent) access paid APIs programmatically, with no manual 
 
 * Node.js (v20 or higher)
 * An x402-compatible server to connect to (for this demo, we'll use the [sample express server with weather data](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express) from the x402 repo, or any external x402 API)
-* An Ethereum wallet with USDC (on Base Sepolia or Base Mainnet)
+* An Ethereum wallet with USDC (on Base Sepolia or Base Mainnet), or a Solana wallet with USDC (on Solana Testnet or Solana Mainnet)
 * [Claude Desktop with MCP support](https://claude.ai/download)
 
 ***

--- a/guides/mcp-server-with-x402.md
+++ b/guides/mcp-server-with-x402.md
@@ -18,7 +18,7 @@ This lets you (or your agent) access paid APIs programmatically, with no manual 
 
 * Node.js (v20 or higher)
 * An x402-compatible server to connect to (for this demo, we'll use the [sample express server with weather data](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express) from the x402 repo, or any external x402 API)
-* An Ethereum wallet with USDC (on Base Sepolia or Base Mainnet), or a Solana wallet with USDC (on Solana Testnet or Solana Mainnet)
+* An Ethereum wallet with USDC (on Base Sepolia or Base Mainnet), or a Solana wallet with USDC (on Solana Devnet or Solana)
 * [Claude Desktop with MCP support](https://claude.ai/download)
 
 ***


### PR DESCRIPTION
## Summary
- Added Solana and Solana testnet support to network support tables
- Updated facilitator support documentation for x402.org and CDP facilitators
- Added Solana wallet setup instructions using SolanaKit
- Updated FAQ with Solana network and asset information

## Changes
- `core-concepts/network-and-token-support.md`: Updated network support tables to include Solana/Solana testnet
- `faq.md`: Added Solana and Solana testnet to supported assets table
- `getting-started/quickstart-for-buyers.md`: Added Solana wallet creation section with SolanaKit example
- `getting-started/quickstart-for-sellers.md`: Minor formatting fixes
- `guides/mcp-server-with-x402.md`: Updated prerequisites to mention Solana wallet option